### PR TITLE
Output mod_muc's message containing unicode by the lager module

### DIFF
--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -162,7 +162,9 @@
                                           | {'ok', 'undefined' | pid(), _}.
 start(Host, ServerHost, Access, Room, HistorySize, RoomShaper, HttpAuthPool,
       Creator, Nick, DefRoomOpts) ->
-    ?SUPERVISOR_START.
+            io:setopts(standard_io, [{encoding, unicode}]),
+            io:setopts(standard_error, [{unicode, true}]),
+            ?SUPERVISOR_START.
 
 
 -spec start(Host :: jid:server(), ServerHost :: jid:server(),

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -2585,10 +2585,19 @@ add_message_to_history(FromNick, FromJID, Packet, StateData) ->
     Q1 = lqueue_in({FromNick, TSPacket, HaveSubject, TimeStamp, Size},
            StateData#state.history),
     add_to_log(text, {FromNick, Packet}, StateData),
+    output_message_to_log(FromJID, StateData#state.jid, Packet),
     ejabberd_hooks:run(room_packet, StateData#state.host,
                        [FromNick, FromJID, StateData#state.jid, Packet]),
     StateData#state{history = Q1}.
 
+-spec output_message_to_log(jid:jid(), jid:jid(), exml:element()) -> 'ok'.
+output_message_to_log(From, To, Packet) ->
+    BodyTag = exml_query:path(Packet, [{element, <<"body">>}]),
+    Body = exml_query:cdata(BodyTag),
+    ?INFO_MSG("Event=send_message From=~s To=~s Body=~ts",
+    [jid:to_binary(jid:to_bare(From)),
+    jid:to_binary(jid:to_bare(To)),
+    Body]).
 
 -spec send_history(jid:jid(), Shift :: non_neg_integer(), state()) -> boolean().
 send_history(JID, Shift, StateData) ->


### PR DESCRIPTION
This PR adds support for outputing mod_muc's log to standard i/o. And lager(io:format) cannot display well when it include unicode characters. Fix it.