### PR TITLE
Add UUID to muc's message

### DIFF
--- a/src/jlib.erl
+++ b/src/jlib.erl
@@ -39,6 +39,7 @@
          replace_from_to_attrs/3,
          replace_from_to/3,
          remove_attr/2,
+         add_attr/3,
          iq_query_info/1,
          iq_query_or_response_info/1,
          iq_to_xml/1,
@@ -272,6 +273,11 @@ replace_from_to(From, To, XE = #xmlel{attrs = Attrs}) ->
 -spec remove_attr(binary(), exml:element()) -> exml:element().
 remove_attr(Attr, XE = #xmlel{attrs = Attrs}) ->
     NewAttrs = lists:keydelete(Attr, 1, Attrs),
+    XE#xmlel{attrs = NewAttrs}.
+
+-spec add_attr(binary(), binary(), exml:element()) -> exml:element().
+add_attr(Attr, Value, XE = #xmlel{attrs = Attrs}) ->
+    NewAttrs = [{Attr, Value} | Attrs],
     XE#xmlel{attrs = NewAttrs}.
 
 -spec iq_query_info(exml:element()) -> 'invalid' | 'not_iq' | 'reply' | iq().

--- a/src/mod_muc_commands.erl
+++ b/src/mod_muc_commands.erl
@@ -188,7 +188,7 @@ message(Sender, Recipient, Type, Contents)
     Addresses = address_attributes(Sender, Recipient),
     Attributes = case Type of
                      <<>> -> Addresses;
-                     _ -> [{<<"type">>, Type}|Addresses]
+                     _ -> [{<<"id">>, uuid:uuid_to_string(uuid:get_v4(), binary_standard)}, {<<"type">>, Type}|Addresses]
                  end,
     #xmlel{name = <<"message">>,
            attrs = Attributes,

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -2612,10 +2612,11 @@ add_message_to_history(FromNick, FromJID, Packet, StateData) ->
 
 -spec output_message_to_log(jid:jid(), jid:jid(), exml:element()) -> 'ok'.
 output_message_to_log(From, To, Packet) ->
-    BodyTag = exml_query:path(Packet, [{element, <<"body">>}]),
-    Body = exml_query:cdata(BodyTag),
-    ?INFO_MSG("Event=send_message From=~s To=~s Body=~ts",
-    [jid:to_binary(jid:to_bare(From)),
+    StanzaId = exml_query:attr(Packet, <<"id">>),
+    Body = exml_query:path(Packet, [{element, <<"body">>}, cdata]),
+    ?INFO_MSG("Event=send_message Id=~s From=~s To=~s Body=~ts",
+    [StanzaId,
+    jid:to_binary(jid:to_bare(From)),
     jid:to_binary(jid:to_bare(To)),
     Body]).
 

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -443,12 +443,17 @@ normal_state({route, From, <<>>, _Acc,
              StateData) ->
     Lang = xml:get_attr_s(<<"xml:lang">>, Attrs),
     Type = xml:get_attr_s(<<"type">>, Attrs),
-
+    NewPacket = case exml_query:attr(Packet, <<"id">>) of
+                    undefined ->
+                        jlib:add_attr(<<"id">>, uuid:uuid_to_string(uuid:get_v4(), binary_standard), Packet);
+                    _ ->
+                        Packet
+                end,
     NewStateData = route_message(#routed_message{
         allowed = can_send_to_conference(From, StateData),
         type = Type,
         from = From,
-        packet = Packet,
+        packet = NewPacket,
         lang = Lang}, StateData),
     next_normal_state(NewStateData);
 normal_state({route, From, <<>>, Acc0,


### PR DESCRIPTION
Need uniquely identifiable id for muc messages to display/hide it.

