### PR TITLE
Tuning server performance

### DIFF
--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -781,7 +781,7 @@ register_room(Host, Room, Pid) ->
                     {exists, R#muc_online_room.pid}
             end
         end,
-    mnesia:transaction(F).
+    mnesia:async_dirty(F).
 
 
 -spec room_jid_to_pid(RoomJID :: jid:jid()) -> {ok, pid()} | {error, not_found}.

--- a/src/mod_muc_commands.erl
+++ b/src/mod_muc_commands.erl
@@ -23,6 +23,7 @@
 -export([start/2, stop/1]).
 
 -export([create_instant_room/4]).
+-export([room_destroyed/2]).
 -export([invite_to_room/5]).
 -export([send_message_to_room/4]).
 -export([kick_user_from_room/3]).
@@ -55,6 +56,18 @@ commands() ->
         {owner, binary},
         {nick, binary}]},
       {result, {name, binary}}],
+
+     [{name, delete_muc_room},
+      {category, <<"mucs">>},
+      {desc, <<"Delete a MUC room.">>},
+      {module, ?MODULE},
+      {function, room_destroyed},
+      {action, delete},
+      {identifiers, [host, name]},
+      {args,
+       [{host, binary},
+        {name, binary}]},
+      {result, ok}],
 
      [{name, invite_to_muc_room},
       {category, <<"mucs">>},
@@ -127,6 +140,15 @@ create_instant_room(Host, Name, Owner, Nick) ->
             {error, room_remains_locked};
         {error, not_found} = E ->
             E
+    end.
+
+room_destroyed(Host, Name) ->
+    R = jid:from_binary(room_address(Name, Host)),
+    case mod_muc:room_jid_to_pid(R) of
+        {ok, Pid} ->
+            gen_fsm:send_all_state_event(Pid, destroy);
+        {error, Reason} ->
+            {error, Reason}
     end.
 
 invite_to_room(Host, Name, Sender, Recipient, Reason) ->


### PR DESCRIPTION
* muc_online_roomテーブルへの書き込みについて

チャットルーム情報については必要なデータは game-database で管理されており、重複したデータが送信されることは基本的にはないので、transanctionを貼らずにread, writeを行っても問題ない。
ここの処理で現状詰まるため、非同期で強制的に書き込むように変更する

* roomを削除するAPIを追加する

一時的なチャットルーム情報が消えていなかったので実装した。
ステージorロビーが無くなるとき、チャットグループが削除された時にapi-serverが呼ぶようにして欲しい。